### PR TITLE
Grammar and punctuation fixes in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ class App extends Component {
         <Sky 
           images={{
             /* FORMAT AS FOLLOWS */
-            0: "https://linkToYourImage0",  /* You can pass as much images as you want */
+            0: "https://linkToYourImage0",  /* You can pass as many images as you want */
             1: "https://linkToYourImage1",
-            2: myImage /* you can pass images in any form: link, imported via webpack.. */
-            /* 3: your other image.. */
-            /* 4: your other image.. */
-            /* 5: your other image.. */
+            2: myImage /* you can pass images in any form: link, imported via webpack... */
+            /* 3: your other image... */
+            /* 4: your other image... */
+            /* 5: your other image... */
             /* ... */
           }}
           how={130} /* Pass the number of images Sky will render chosing randomly */

--- a/module/README.md
+++ b/module/README.md
@@ -33,12 +33,12 @@ class App extends Component {
         <Sky 
           images={{
             /* FORMAT AS FOLLOWS */
-            0: "https://linkToYourImage0",  /* You can pass as much images as you want */
+            0: "https://linkToYourImage0",  /* You can pass as many images as you want */
             1: "https://linkToYourImage1",
-            2: myImage /* you can pass images in any form: link, imported via webpack.. */
-            /* 3: your other image.. */
-            /* 4: your other image.. */
-            /* 5: your other image.. */
+            2: myImage /* you can pass images in any form: link, imported via webpack... */
+            /* 3: your other image... */
+            /* 4: your other image... */
+            /* 5: your other image... */
             /* ... */
           }}
           how={130} /* Pass the number of images Sky will render chosing randomly */


### PR DESCRIPTION
This makes a grammatical change in the comment explaining the format and makes all ellipses use three periods.