### PR TITLE
Fix image tag markup

### DIFF
--- a/module/src/item.js
+++ b/module/src/item.js
@@ -47,7 +47,7 @@ class Item extends React.Component {
 
     return (
       <div style={style}>
-        <img style={size} srcSet={this.props.what} alt="img" />
+        <img style={size} src={this.props.what} alt="" />
       </div>
     );
   }

--- a/src/components/sky/item.js
+++ b/src/components/sky/item.js
@@ -47,7 +47,7 @@ class Item extends React.Component {
 
     return (
       <div style={style}>
-        <img style={size} srcSet={this.props.what} alt="img" />
+        <img style={size} src={this.props.what} alt="" />
       </div>
     );
   }


### PR DESCRIPTION
- replacing `alt="image"` with `alt=""` the reason that the images are just for decoration.
- replacing `srcSet` with `src`. srcset for changing resolutions and not compatible with all browsers.